### PR TITLE
Throw verbose AccessTokenException if access token is null

### DIFF
--- a/Cimpress.FulfillmentLocationNetCore/Errors/AccessTokenException.cs
+++ b/Cimpress.FulfillmentLocationNetCore/Errors/AccessTokenException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Cimpress.FulfillmentLocationNetCore.Errors
+{
+    public class AccessTokenException : Exception
+    {
+        public AccessTokenException() { }
+        public AccessTokenException(string message) : base(message) { }
+        public AccessTokenException(string message, Exception inner) : base(message, inner) { }
+        protected AccessTokenException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+}

--- a/Cimpress.FulfillmentLocationNetCore/FulfillmentLocationClient.cs
+++ b/Cimpress.FulfillmentLocationNetCore/FulfillmentLocationClient.cs
@@ -83,6 +83,13 @@ namespace Cimpress.FulfillmentLocationNetCore
             _httpClient.DefaultRequestHeaders.Add("UserAgent", "Fulfillment Location .NET Core Client by Cimpress");
         }
 
+        private string _GetAuthorization() {
+            var auth = _authorizationProvider();
+            if (auth == null) {
+                throw new AccessTokenException("The access token was null. Did you specify an authorization provider that returned a null value?");
+            }
+            return auth;
+        }
         private async Task<ICollection<FulfillmentLocation>> _GetFulfillmentLocations(string fulfillerId = null, bool showArchived = false)
         {
             var builder = new UriBuilder(_url);
@@ -102,7 +109,7 @@ namespace Cimpress.FulfillmentLocationNetCore
                 RequestUri = builder.Uri,
                 Method = HttpMethod.Get,
                 Headers = {
-                    { "Authorization", _authorizationProvider() },
+                    { "Authorization", _GetAuthorization() },
                 }
             };
             var response = await _httpClient.SendAsync(request);
@@ -163,7 +170,7 @@ namespace Cimpress.FulfillmentLocationNetCore
                 RequestUri = builder.Uri,
                 Method = HttpMethod.Post,
                 Headers = {
-                    { "Authorization", _authorizationProvider() },
+                    { "Authorization", _GetAuthorization() },
                 },
                 Content = new StringContent(
                     JsonConvert.SerializeObject(locationConfiguration),
@@ -209,7 +216,7 @@ namespace Cimpress.FulfillmentLocationNetCore
                 RequestUri = builder.Uri,
                 Method = HttpMethod.Get,
                 Headers = {
-                    { "Authorization", _authorizationProvider() }
+                    { "Authorization", _GetAuthorization() }
                 }
             };
             var response = await _httpClient.SendAsync(request);
@@ -259,7 +266,7 @@ namespace Cimpress.FulfillmentLocationNetCore
                 RequestUri = builder.Uri,
                 Method = HttpMethod.Put,
                 Headers = {
-                    { "Authorization", _authorizationProvider() }
+                    { "Authorization", _GetAuthorization() }
                 },
                 Content = new StringContent(
                     JsonConvert.SerializeObject(locationConfiguration),
@@ -313,7 +320,7 @@ namespace Cimpress.FulfillmentLocationNetCore
                 RequestUri = builder.Uri,
                 Method = HttpMethod.Delete,
                 Headers = {
-                    { "Authorization", _authorizationProvider() }
+                    { "Authorization", _GetAuthorization() }
                 }
             };
             var response = await _httpClient.SendAsync(request);


### PR DESCRIPTION
Closes #2 

The procurement of the authorization header value has been relegated to a different method, one that throws an `AccessTokenException` if the value of the header is null. 